### PR TITLE
[update]不要なログ消しました。

### DIFF
--- a/src/components/Navigation.vue
+++ b/src/components/Navigation.vue
@@ -86,7 +86,7 @@
         </v-btn>
       </template> -->
     </v-app-bar>
-    {{avatar}}
+    <!-- {{avatar}} -->
   </div>
 </template>
 


### PR DESCRIPTION
プロフィール画像の変更は
プロフィール編集画面→画像を選択→UPLOAD→画面更新
で変更されます。
ナビゲーションの自分のプロフィールしか画像は表示されません。
そのため、フォローやフォロワーの画像は初期画像のままです。
